### PR TITLE
Fix version conflicts caused by PR#129

### DIFF
--- a/GDNET.Deploy/GDNET.Deploy.csproj
+++ b/GDNET.Deploy/GDNET.Deploy.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="ppy.osu.Framework" Version="2019.1108.0" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="ppy.osu.Framework" Version="2021.714.0" />
         <PackageReference Include="ppy.squirrel.windows" Version="1.9.0.4" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0-preview2.19523.17" />
         <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump ppy.osu.Framework from 2019.1108.0 to 2021.714.0. [(PR#129)](https://github.com/GDdotNET/GDNET/pull/129).
Hope this fix can help you.

Best regards,
sucrose